### PR TITLE
readme: update the name of the PyCharm plugin in all the README files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ there is not already a category that meets your needs.
   spaces. 
 * Each sample must include at least the following files inside its directory:
   * `README.md` This file describes the sample functionality, requirements,
-    setup, etc. and is used by the **XBee MicroPython plugin for PyCharm**
+    setup, etc. and is used by the **Digi XBee MicroPython PyCharm Plugin**
     to list the sample in the import samples wizard. For that reason, it must
     have a specific structure with required sections. You can copy and modify
     file [README_TEMPLATE.md](samples/README_TEMPLATE.md) from `samples/`
@@ -92,7 +92,7 @@ there is not already a category that meets your needs.
   and without blank spaces.
 * Each library must include at least the following files inside its directory:
   * `README.md` This file describes the library functionality and requirements
-    and is used by the **XBee MicroPython plugin for PyCharm** to list the
+    and is used by the **Digi XBee MicroPython PyCharm Plugin** to list the
     library when creating a new project. For that reason, it must have a
     specific structure with required sections. You can copy and modify file
     [README_TEMPLATE.md](lib/README_TEMPLATE.md) from `lib/` directory for

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ modifying existing code to address differences between the XBee and other
 MicroPython platforms. This project includes code from
 [micropython-lib][micropython-lib].
 
-The repository is used by the **XBee MicroPython plugin for PyCharm** to
+The repository is used by the **Digi XBee MicroPython PyCharm Plugin** to
 get the available samples, libraries platforms and stubs and facilitate the
 process of creating and launching MicroPython applications in XBee devices.
 This means that you don't need to clone it unless you want to contribute
@@ -16,7 +16,7 @@ automatically.
 
 We don't recommend you to do so, but you can still use the content of this
 repository to create XBee MicroPython applications by your own (without using
-the **XBee MicroPython plugin for PyCharm**). In any case, you will find
+the **Digi XBee MicroPython PyCharm Plugin**). In any case, you will find
 information on how to get started with XBee and MicroPython in the
 [Digi MicroPython Programming Guide][doc].
 
@@ -50,15 +50,15 @@ The repository is structured in the following folders:
   correct location for `import umqtt.simple` to work in your program.
 * **platforms** - This folder contains the definition and images for the 
   Digi XBee products supporting MicroPython. This information is used by the
-  **Digi XBee MicroPython plugin for PyCharm** to list the supported platforms.
+  **Digi XBee MicroPython PyCharm Plugin** to list the supported platforms.
 * **samples** - Files in the `samples/` directory are organized by feature or
   XBee device. For example, `cellular` contains samples for XBee3 Cellular
   devices and `i2c` contains samples for any XBee device with I2C support in
   MicroPython.
 * **typehints** - This folder contains the API definitions of the MicroPython
   modules available in the XBee devices. These definitions are used by the
-  **Digi XBee MicroPython plugin for PyCharm** for syntax checking, code
-  completion and refactoring.
+  **Digi XBee MicroPython PyCharm Plugin** for syntax checking, code completion
+  and refactoring.
 
 
 Usage

--- a/lib/README.md
+++ b/lib/README.md
@@ -6,7 +6,7 @@ applications to benefit from the methods and abstractions they offer.
 Libraries are organized in categories, which are directories that group them
 by feature or functionality. 
 
-**XBee MicroPython plugin for PyCharm** uses this folder to list and import
+**Digi XBee MicroPython PyCharm Plugin** uses this folder to list and import
 libraries when creating a new project.
 
 Contributing

--- a/platforms/README.md
+++ b/platforms/README.md
@@ -3,5 +3,5 @@ XBee MicroPython Platforms
 
 This folder contains the definition and images for the Digi XBee products
 supporting MicroPython. This information is used by the **Digi XBee MicroPython
-plugin for PyCharm** to list the supported platforms when creating a new
+PyCharm Plugin** to list the supported platforms when creating a new
 application or importing a sample.

--- a/samples/README.md
+++ b/samples/README.md
@@ -5,7 +5,7 @@ This directory contains sample applications that demonstrate the use of XBee
 MicroPython modules and libraries. Samples are organized in categories, which
 are directories that group samples by feature or functionality. 
 
-**XBee MicroPython plugin for PyCharm** uses this folder to list the available
+**Digi XBee MicroPython PyCharm Plugin** uses this folder to list the available
 samples in the **Import XBee MicroPython Sample Project** wizard.
 
 Contributing

--- a/samples/README_TEMPLATE.md
+++ b/samples/README_TEMPLATE.md
@@ -72,10 +72,11 @@ Required libraries
 
 > OPTIONAL
 >
-> This section is used by the **XBee MicroPython plugin for PyCharm** to import
-> the libraries required by the sample application once the sample is imported.
-> The content of the section is a list with the ID of required libraries from
-> the `lib` directory. ID must equal the name of the library folder.
+> This section is used by the **Digi XBee MicroPython PyCharm Plugin** to
+> import the libraries required by the sample application once the sample is
+> imported. The content of the section is a list with the ID of required
+> libraries from the `lib` directory. ID must equal the name of the library
+> folder.
 > 
 > You can remove this section if the sample does not require any library.
 > 

--- a/typehints/README.md
+++ b/typehints/README.md
@@ -2,6 +2,6 @@ XBee MicroPython Typehints
 ==========================
 
 This folder contains the API definitions of the MicroPython modules available
-in the XBee devices. These definitions are used by the **XBee MicroPython
-plugin for PyCharm** for syntax checking, code completion and refactoring
-when writing your application.
+in the XBee devices. These definitions are used by the **Digi XBee MicroPython
+PyCharm Plugin** for syntax checking, code completion and refactoring when
+writing your application.


### PR DESCRIPTION
- Official new name for the product is 'Digi XBee MicroPython PyCharm Plugin'.
  All references to the old name (XBee MicroPython plugin for PyCharm) have
  been updated in all the README files.

Signed-off-by: Diego Escalona <diego.escalona@digi.com>