### PR TITLE
samples: set correct minimum firmware version of XBee3 802.15.4 and DigiMesh platforms in the relay frames samples

### DIFF
--- a/samples/xbee/communication/relay_frames/README.md
+++ b/samples/xbee/communication/relay_frames/README.md
@@ -64,8 +64,8 @@ Supported platforms
 -------------------
 
 * Digi XBee3 Zigbee 3 - minimum firmware version: 1006
-* Digi XBee3 802.15.4 - minimum firmware version: 2003
-* Digi XBee3 DigiMesh 2.4 - minimum firmware version: 3002
+* Digi XBee3 802.15.4 - minimum firmware version: 2004
+* Digi XBee3 DigiMesh 2.4 - minimum firmware version: 3003
 * Digi XBee3 Cellular LTE-M/NB-IoT - minimum firmware version: 11410
 * Digi XBee3 Cellular LTE Cat 1 - minimum firmware version: 31010
 * Digi XBee Cellular 3G - minimum firmware version: 1130B

--- a/samples/xbee/communication/relay_frames_button/README.md
+++ b/samples/xbee/communication/relay_frames_button/README.md
@@ -53,8 +53,8 @@ Supported platforms
 -------------------
 
 * Digi XBee3 Zigbee 3 - minimum firmware version: 1006
-* Digi XBee3 802.15.4 - minimum firmware version: 2003
-* Digi XBee3 DigiMesh 2.4 - minimum firmware version: 3002
+* Digi XBee3 802.15.4 - minimum firmware version: 2004
+* Digi XBee3 DigiMesh 2.4 - minimum firmware version: 3003
 * Digi XBee3 Cellular LTE-M/NB-IoT - minimum firmware version: 11410
 * Digi XBee3 Cellular LTE Cat 1 - minimum firmware version: 31010
 * Digi XBee Cellular 3G - minimum firmware version: 1130B

--- a/samples/xbee/communication/relay_frames_led/README.md
+++ b/samples/xbee/communication/relay_frames_led/README.md
@@ -67,8 +67,8 @@ Supported platforms
 -------------------
 
 * Digi XBee3 Zigbee 3 - minimum firmware version: 1006
-* Digi XBee3 802.15.4 - minimum firmware version: 2003
-* Digi XBee3 DigiMesh 2.4 - minimum firmware version: 3002
+* Digi XBee3 802.15.4 - minimum firmware version: 2004
+* Digi XBee3 DigiMesh 2.4 - minimum firmware version: 3003
 * Digi XBee3 Cellular LTE-M/NB-IoT - minimum firmware version: 11410
 * Digi XBee3 Cellular LTE Cat 1 - minimum firmware version: 31010
 * Digi XBee Cellular 3G - minimum firmware version: 1130B

--- a/samples/xbee/communication/relay_frames_temperature/README.md
+++ b/samples/xbee/communication/relay_frames_temperature/README.md
@@ -44,8 +44,8 @@ Supported platforms
 -------------------
 
 * Digi XBee3 Zigbee 3 - minimum firmware version: 1006
-* Digi XBee3 802.15.4 - minimum firmware version: 2003
-* Digi XBee3 DigiMesh 2.4 - minimum firmware version: 3002
+* Digi XBee3 802.15.4 - minimum firmware version: 2004
+* Digi XBee3 DigiMesh 2.4 - minimum firmware version: 3003
 * Digi XBee3 Cellular LTE-M/NB-IoT - minimum firmware version: 11410
 * Digi XBee3 Cellular LTE Cat 1 - minimum firmware version: 31010
 


### PR DESCRIPTION
Only Zigbee and Cellular modules support relay frames communication at
this time.

Signed-off-by: Ruben Moral <ruben.moral@digi.com>