### PR TITLE
samples/cellular/http_request: Fix Host header

### DIFF
--- a/samples/cellular/http_request/main.py
+++ b/samples/cellular/http_request/main.py
@@ -47,7 +47,7 @@ try:
     # Connect to the host using the port 80 (HTTP).
     s.connect((host, 80))
 
-    request = bytes("GET /%s HTTP/1.1\r\nHost: %s...\r\n\r\n" % (path, host), "utf8")
+    request = bytes("GET /%s HTTP/1.1\r\nHost: %s\r\n\r\n" % (path, host), "utf8")
     print("Requesting /%s from host %s\n" % (path, host))
 
     # Send the HTTP request.


### PR DESCRIPTION
I'm not sure how the errant `...` ended up in the example. But it certainly does not belong there.