### PR TITLE
samples: add 'eddystonebeacon' library as required in eddystone samples

### DIFF
--- a/samples/bluetooth/eddystone_advertise/README.md
+++ b/samples/bluetooth/eddystone_advertise/README.md
@@ -37,6 +37,11 @@ Once the following is printed:
 The XBee is sending out advertisements containing Eddystone beacons.
 They will be also be printed out as they are advertised.
 
+Required libraries
+--------------------
+
+* eddystonebeacon
+
 Supported platforms
 -------------------
 

--- a/samples/bluetooth/eddystone_scan/README.md
+++ b/samples/bluetooth/eddystone_scan/README.md
@@ -40,6 +40,11 @@ Once the following is printed:
 The XBee is scanning for advertisements to pass off to the Eddystone parser.
 They will be parsed and its information will be printed out.
 
+Required libraries
+--------------------
+
+* eddystonebeacon
+
 Supported platforms
 -------------------
 


### PR DESCRIPTION
This way, the PyCharm plugin will add the library automatically when
importing the sample project.

Signed-off-by: Ruben Moral <ruben.moral@digi.com>