### PR TITLE
Fix iBeacon library README.md

### DIFF
--- a/lib/iBeacon/README.md
+++ b/lib/iBeacon/README.md
@@ -1,14 +1,12 @@
-#
-# DEVELOPER IS RESPONSIBLE FOR OBTAINING THE NECESSARY LICENSES FROM APPLE.
-#
-# iBeacon(TM) is a trademark of Apple Inc. and use of this code must comply with
-# their licence.
-#
-
-iBeacon Library
-======================================
+iBeacon Library (SEE LICENSE NOTICE)
+====================================
 
 MicroPython library for creating and parsing iBeacon frames.
+
+**DEVELOPER IS RESPONSIBLE FOR OBTAINING THE NECESSARY LICENSES FROM APPLE.
+iBeacon(TM) is a trademark of Apple Inc. and use of this code must comply with
+their licence.**
+
 
 Supported platforms
 -------------------


### PR DESCRIPTION
Since the PyCharm plugin pulls the "title" of the document as the library name,
the iBeacon library is currently showing up as:

    ## DEVELOPER IS RESPONSIBLE FOR OBTAINING THE NECESSARY LICENSES FROM APPLE.## iBeacon(TM) is a trademark of Apple Inc. and use of this code must comply with# their licence.#iBeacon Library

This is clearly not what we intended.

Based on my understanding of how the plugin reads/formats the library description, I think this should suffice.