### PR TITLE
Samples: Fix datapoints upload in the DRM sample 

### DIFF
--- a/samples/remote_manager/drm_http_requests/main.py
+++ b/samples/remote_manager/drm_http_requests/main.py
@@ -92,7 +92,7 @@ else:
 while True:
     temperature = int(xbee.atcmd('TP') * 9.0 / 5.0 + 32.0)
     print("- Uploading datapoint to datastream '%s'... " % STREAM_ID, end="")
-    if create_datastream(STREAM_ID, STREAM_DESC, STREAM_TYPE, STREAM_UNITS):
+    if upload_datapoint(STREAM_ID, temperature):
         print("[OK]")
     else:
         print("[ERROR]")


### PR DESCRIPTION
The remote manager sample is actually supposed to upload datapoints using the method upload_datapoint in the while loop. Instead, while loop is creating datastreams. A small fix.