### PR TITLE
samples: treat atcmd('TP') as signed 16-bit value

### DIFF
--- a/samples/bluetooth/eddystone_advertise/main.py
+++ b/samples/bluetooth/eddystone_advertise/main.py
@@ -69,6 +69,9 @@ battery_voltage = 0
 while True:
     time_alive = time.ticks_diff(time.ticks_ms(), start_time) / 1000
     beacon_temperature = xbee.atcmd('TP')
+    # convert unsigned 16-bit value to signed beacon_temperature
+    if beacon_temperature > 0x7FFF:
+        beacon_temperature = beacon_temperature - 0x10000
     # If the %V command is supported (XBee 3 LTE-M) the following line can be uncommented.
     # battery_voltage = xbee.atcmd('%V') / 1000
 

--- a/samples/filesystem/main.py
+++ b/samples/filesystem/main.py
@@ -52,6 +52,9 @@ with uio.open(LOG_FILE, mode="a") as log:
     stopped = False
     while not stopped:
         temperature = xbee.atcmd("TP")
+        # convert unsigned 16-bit value to signed temperature
+        if temperature > 0x7FFF:
+            temperature = temperature - 0x10000
         # Write the current temperature in the log file.
         dummy = log.write("Current temperature: %.1F C (%.1F F)\n" % (temperature, temperature * 9.0 / 5.0 + 32.0))
         # Wait 1 second until the next reading.

--- a/samples/remote_manager/drm_http_requests/main.py
+++ b/samples/remote_manager/drm_http_requests/main.py
@@ -90,7 +90,11 @@ else:
 
 # Start uploading temperature samples.
 while True:
-    temperature = int(xbee.atcmd('TP') * 9.0 / 5.0 + 32.0)
+    temperature = xbee.atcmd("TP")
+    # convert unsigned 16-bit value to signed temperature
+    if temperature > 0x7FFF:
+        temperature = temperature - 0x10000
+    temperature = int(temperature * 9.0 / 5.0 + 32.0)
     print("- Uploading datapoint to datastream '%s'... " % STREAM_ID, end="")
     if upload_datapoint(STREAM_ID, temperature):
         print("[OK]")

--- a/samples/remote_manager/send_data_points/main.py
+++ b/samples/remote_manager/send_data_points/main.py
@@ -36,7 +36,11 @@ while True:
 
     # Read the temperature every 5 seconds during a minute.
     for i in range(12):
-        temperature = int(xbee.atcmd('TP') * 9.0 / 5.0 + 32.0)
+        temperature = xbee.atcmd("TP")
+        # convert unsigned 16-bit value to signed temperature
+        if temperature > 0x7FFF:
+            temperature = temperature - 0x10000
+        temperature = int(temperature * 9.0 / 5.0 + 32.0)
         data.add(DATAPOINT_TEMPERATURE, temperature)
         time.sleep(5)
 

--- a/samples/xbee/at_commands/main.py
+++ b/samples/xbee/at_commands/main.py
@@ -35,6 +35,9 @@ print("Hardware version: " + hw_version)
 
 # Read the module's temperature.
 temperature = xbee.atcmd("TP")
+# convert unsigned 16-bit value to signed temperature
+if temperature > 0x7FFF:
+    temperature = temperature - 0x10000
 print("The XBee is %.1F C (%.1F F)" % (temperature, temperature * 9.0 / 5.0 + 32.0))
 
 # Configure the module's node identifier and read it.


### PR DESCRIPTION
Some XBee modules are rated for temperatures below 0°C.  `ATTP` returns a signed 16-bit value, but `xbee.atcmd()` returns an unsigned value (0 to 0xFFFF).  These samples now check for negative values (0x8000 to 0xFFFF) and convert them accordingly.

(This was a customer-reported issue, and I do not have a set up to reproduce it with "freeze spray" to cool the module below 0°C.  Can someone else do any testing before we merge these changes?)