### PR TITLE
platforms: revert support of XBee BLU platform from some examples and libraries

### DIFF
--- a/lib/sensor/ds1621/README.md
+++ b/lib/sensor/ds1621/README.md
@@ -17,4 +17,3 @@ Supported platforms
 * Digi XBee 3 Global LTE-M/NB-IoT - minimum firmware version: x18
 * Digi XBee 3 Global LTE Cat 1 - minimum firmware version: 11519
 * Digi XBee 3 North America LTE Cat 1 - minimum firmware version: 41519
-* Digi XBee BLU - minimum firmware version: 4000

--- a/lib/sensor/hdc1080/README.md
+++ b/lib/sensor/hdc1080/README.md
@@ -17,4 +17,3 @@ Supported platforms
 * Digi XBee 3 Global LTE-M/NB-IoT - minimum firmware version: x18
 * Digi XBee 3 Global LTE Cat 1 - minimum firmware version: 11519
 * Digi XBee 3 North America LTE Cat 1 - minimum firmware version: 41519
-* Digi XBee BLU - minimum firmware version: 4000

--- a/samples/i2c/i2c_ds1621_library/README.md
+++ b/samples/i2c/i2c_ds1621_library/README.md
@@ -82,12 +82,11 @@ Supported platforms
 * Digi XBee 3 Global LTE-M/NB-IoT - minimum firmware version: x18
 * Digi XBee 3 Global LTE Cat 1 - minimum firmware version: 11519
 * Digi XBee 3 North America LTE Cat 1 - minimum firmware version: 41519
-* Digi XBee BLU - minimum firmware version: 4000
 
 License
 -------
 
-Copyright (c) 2019-2024, Digi International, Inc.
+Copyright (c) 2019, Digi International, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/samples/i2c/i2c_eeprom/README.md
+++ b/samples/i2c/i2c_eeprom/README.md
@@ -108,12 +108,11 @@ Supported platforms
 * Digi XBee 3 Global LTE-M/NB-IoT - minimum firmware version: x18
 * Digi XBee 3 Global LTE Cat 1 - minimum firmware version: 11519
 * Digi XBee 3 North America LTE Cat 1 - minimum firmware version: 41519
-* Digi XBee BLU - minimum firmware version: 4000
 
 License
 -------
 
-Copyright (c) 2019-2024, Digi International, Inc.
+Copyright (c) 2019, Digi International, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/samples/i2c/i2c_hdc1080/README.md
+++ b/samples/i2c/i2c_hdc1080/README.md
@@ -77,12 +77,11 @@ Supported platforms
 * Digi XBee 3 Global LTE-M/NB-IoT - minimum firmware version: x18
 * Digi XBee 3 Global LTE Cat 1 - minimum firmware version: 11519
 * Digi XBee 3 North America LTE Cat 1 - minimum firmware version: 41519
-* Digi XBee BLU - minimum firmware version: 4000
 
 License
 -------
 
-Copyright (c) 2019-2024, Digi International, Inc.
+Copyright (c) 2019, Digi International, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/samples/i2c/i2c_hdc1080_library/README.md
+++ b/samples/i2c/i2c_hdc1080_library/README.md
@@ -86,12 +86,11 @@ Supported platforms
 * Digi XBee 3 Global LTE-M/NB-IoT - minimum firmware version: x18
 * Digi XBee 3 Global LTE Cat 1 - minimum firmware version: 11519
 * Digi XBee 3 North America LTE Cat 1 - minimum firmware version: 41519
-* Digi XBee BLU - minimum firmware version: 4000
 
 License
 -------
 
-Copyright (c) 2019-2024, Digi International, Inc.
+Copyright (c) 2019, Digi International, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/samples/i2c/i2c_scanner/README.md
+++ b/samples/i2c/i2c_scanner/README.md
@@ -78,12 +78,11 @@ Supported platforms
 * Digi XBee 3 Global LTE-M/NB-IoT - minimum firmware version: x18
 * Digi XBee 3 Global LTE Cat 1 - minimum firmware version: 11519
 * Digi XBee 3 North America LTE Cat 1 - minimum firmware version: 41519
-* Digi XBee BLU - minimum firmware version: 4000
 
 License
 -------
 
-Copyright (c) 2019-2024, Digi International, Inc.
+Copyright (c) 2019, Digi International, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/samples/pwm_duty/README.md
+++ b/samples/pwm_duty/README.md
@@ -71,12 +71,11 @@ Supported platforms
 * Digi XBee 3 Global LTE-M/NB-IoT - minimum firmware version: x18
 * Digi XBee 3 Global LTE Cat 1 - minimum firmware version: 11519
 * Digi XBee 3 North America LTE Cat 1 - minimum firmware version: 41519
-* Digi XBee BLU - minimum firmware version: 4000
 
 License
 -------
 
-Copyright (c) 2019-2024, Digi International, Inc.
+Copyright (c) 2019, Digi International, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/samples/xbee/communication/relay_frames_temperature/README.md
+++ b/samples/xbee/communication/relay_frames_temperature/README.md
@@ -64,12 +64,11 @@ Supported platforms
 * Digi XBee 3 Global LTE-M/NB-IoT - minimum firmware version: x18
 * Digi XBee 3 Global LTE Cat 1 - minimum firmware version: 11519
 * Digi XBee 3 North America LTE Cat 1 - minimum firmware version: 41519
-* Digi XBee BLU - minimum firmware version: 4000
 
 License
 -------
 
-Copyright (c) 2019-2024, Digi International, Inc.
+Copyright (c) 2019, Digi International, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
- I2C and PWM interfaces are not supported in the Digi XBee BLU device.